### PR TITLE
fix the bug of indexing a list by -1

### DIFF
--- a/R/backend_encoder.R
+++ b/R/backend_encoder.R
@@ -80,7 +80,7 @@ encoderModel_add_logit_loss = function(logits, labels, weight=1.0){
    ## Add clossifier
    with(tf$name_scope('loss_classifier'), {
        logit_loss = tf$losses$softmax_cross_entropy(
-           tf$one_hot(labels, logits$get_shape()[-1]),
+           tf$one_hot(labels, logits$get_shape()[[logits$get_shape()]]),
            logits,
            scope='loss_logit',
            weights=weight)


### PR DESCRIPTION
I ran scAlign using the following code snippet:
```R
scAlignObj <- scAlignCreateObject(
    sce.objects = data_list,
    labels = labels,
    project.name = "MousePancreas_Supervised"
)
options <- scAlignOptions(
    steps = 10000,
    batch.size = 2000,
    log.every = 2000,
    architecture = "large",
    batch.norm.layer = T,
    num.dim = 128,
    norm = F,
    full.norm = T
)
scAlignMP <- scAlign(scAlignObj,
    options = options,
    encoder.data = "scale.data",
    supervised = "both",
    run.encoder = T,
    run.decoder = T,
    log.dir = "../results/MousePancreas_scAlign_supervised_08_27",
    log.results = T
)
```
and ran into the following error message:
```
[1] "============== Step 1/3: Encoder training ==============="
[1] "Graph construction"
[1] "Adding target walker loss"
[1] "Adding classifier loss "
[1] "Error during alignment, returning scAlign class."
<simpleError in `[.tensorflow.python.framework.tensor_shape.TensorShape`(logits$get_shape(),     -1): i > 0 is not TRUE>
[1] "Error during interpolation, returning scAlign class."
<simpleError in value[[3L]](cond): invalid subscript 'type' in 'reducedDim(<SingleCellExperiment>, type="character", ...)':
  'ALIGNED-GENE' not in 'reducedDimNames(<SingleCellExperiment>)'>
```

After debugging I found the problem lies in a grammar error in line 83, `backend_encoder.R`:
`tf$one_hot(labels, logits$get_shape()[-1])`
where it should be
`tf$one_hot(labels, logits$get_shape()[[length(logits$get_shape())]])`.
(Indexing a list by -1 is only supported on python.)