### PR TITLE
Per batch normalization at embedding generation

### DIFF
--- a/R/backend_encoder.R
+++ b/R/backend_encoder.R
@@ -80,7 +80,7 @@ encoderModel_add_logit_loss = function(logits, labels, weight=1.0){
    ## Add clossifier
    with(tf$name_scope('loss_classifier'), {
        logit_loss = tf$losses$softmax_cross_entropy(
-           tf$one_hot(labels, logits$get_shape()[-1]),
+           tf$one_hot(labels, logits$get_shape()[[logits$get_shape()]]),
            logits,
            scope='loss_logit',
            weights=weight)

--- a/R/backend_encoder.R
+++ b/R/backend_encoder.R
@@ -285,7 +285,7 @@ encoderModel_calc_embedding = function(sess, data, endpoint, test_in, FLAGS, bat
     ix_end = min((i+(batch_size-1)), nrow(data))
     data_in = data[i:ix_end,,drop=FALSE]
     if (FLAGS$norm)
-      data_in = scale(data_in, center = F, scale = colSums(data_in))
+      data_in = scale(data_in, center = F, scale = sqrt(colSums(data_in ** 2)))
     emb[i:ix_end,] = sess$run(endpoint, dict(test_in=data_in))
   }
   return(emb)

--- a/R/backend_encoder.R
+++ b/R/backend_encoder.R
@@ -283,7 +283,10 @@ encoderModel_calc_embedding = function(sess, data, endpoint, test_in, FLAGS, bat
   emb = matrix(nrow=nrow(data), ncol=FLAGS$emb_size, 0)
   for(i in seq(1,nrow(data),batch_size)){
     ix_end = min((i+(batch_size-1)), nrow(data))
-    emb[i:ix_end,] = sess$run(endpoint, dict(test_in=data[i:ix_end,,drop=FALSE]))
+    data_in = data[i:ix_end,,drop=FALSE]
+    if (FLAGS$norm)
+      data_in = scale(data_in, center = F, scale = colSums(data_in))
+    emb[i:ix_end,] = sess$run(endpoint, dict(test_in=data_in))
   }
   return(emb)
 }

--- a/R/scAlign.R
+++ b/R/scAlign.R
@@ -174,7 +174,7 @@ scAlign = function(sce.object,
       ## Testing options ##
       tensorflow::flag_integer('mini_batch', 50, 'Number samples per testing batch.'),
       ## Hardware ##
-      tensorflow::flag_string('cuda_device', options$gpu.device, 'Select the GPU for this job'))
+      tensorflow::flag_string('cuda_device', options$gpu.device, 'Select the GPU for this job'), arguments = c())
 
     ## Verbosity of tensorflow output. Filters: (1 INFO) (2 WARNINGS) (3 ERRORS)
     Sys.setenv(TF_CPP_MIN_LOG_LEVEL=3);

--- a/R/scAlignMulti.R
+++ b/R/scAlignMulti.R
@@ -171,7 +171,7 @@ scAlignMulti = function(sce.object,
       ## Testing options ##
       tensorflow::flag_integer('mini_batch', 50, 'Number samples per testing batch.'),
       ## Hardware ##
-      tensorflow::flag_string('cuda_device', options$gpu.device, 'Select the GPU for this job'))
+      tensorflow::flag_string('cuda_device', options$gpu.device, 'Select the GPU for this job'), arguments = c())
 
     ## Verbosity of tensorflow output. Filters: (1 INFO) (2 WARNINGS) (3 ERRORS)
     Sys.setenv(TF_CPP_MIN_LOG_LEVEL=3);

--- a/R/train_encoder_multi.R
+++ b/R/train_encoder_multi.R
@@ -202,8 +202,8 @@ encoderModel_train_encoder_multi = function(FLAGS, CV, config,
         if(((step %% FLAGS$log_every_n_steps == 0) | (step == 1) | (step == FLAGS$max_steps)) & FLAGS$log.results == TRUE){
           if(step > 1){ print("==================== Saving results =====================") } ## Suppress first save
           ## Save embeddings
-          data_norm = sess$run(tf$nn$l2_normalize(data, axis=as.integer(1), name=paste0("data")))
-          emb = encoderModel_calc_embedding(sess, data_norm, test_emb, test_in, FLAGS)
+          # data_norm = sess$run(tf$nn$l2_normalize(data, axis=as.integer(1), name=paste0("data")))
+          emb = encoderModel_calc_embedding(sess, data, test_emb, test_in, FLAGS)  # replaced data_norm with data
           write.table(emb, file.path(paste0(FLAGS$logdir, '/model_', as.character(CV), '/train/emb_activations_', as.character(step), '.csv')), sep=",", col.names=FALSE, row.names=FALSE)
 
           ## Write summaries

--- a/R/train_encoder_multi.R
+++ b/R/train_encoder_multi.R
@@ -143,11 +143,11 @@ encoderModel_train_encoder_multi = function(FLAGS, CV, config,
       ## the graph-level seed so that it gets a unique random sequence.
       if(FLAGS$random_seed != 0){tf$set_random_seed(FLAGS$random_seed)}
 
-      ## Normalize full data matrix
-      # if(FLAGS$full_norm == TRUE){
-      #   source_data = sess$run(tf$nn$l2_normalize(source_data, axis=as.integer(1)))
-      #   target_data = sess$run(tf$nn$l2_normalize(target_data, axis=as.integer(1)))
-      # }
+      # Normalize full data matrix
+      if(FLAGS$full_norm == TRUE){
+        source_data = sess$run(tf$nn$l2_normalize(source_data, axis=as.integer(1)))
+        target_data = sess$run(tf$nn$l2_normalize(target_data, axis=as.integer(1)))
+      }
 
       # for(op in tf$get_default_graph()$get_operations()){print(op$name)}
 

--- a/R/train_encoder_multi.R
+++ b/R/train_encoder_multi.R
@@ -144,10 +144,10 @@ encoderModel_train_encoder_multi = function(FLAGS, CV, config,
       if(FLAGS$random_seed != 0){tf$set_random_seed(FLAGS$random_seed)}
 
       # Normalize full data matrix
-      if(FLAGS$full_norm == TRUE){
-        source_data = sess$run(tf$nn$l2_normalize(source_data, axis=as.integer(1)))
-        target_data = sess$run(tf$nn$l2_normalize(target_data, axis=as.integer(1)))
-      }
+      # if(FLAGS$full_norm == TRUE){
+      #   source_data = sess$run(tf$nn$l2_normalize(source_data, axis=as.integer(1)))
+      #   target_data = sess$run(tf$nn$l2_normalize(target_data, axis=as.integer(1)))
+      # }
 
       # for(op in tf$get_default_graph()$get_operations()){print(op$name)}
 


### PR DESCRIPTION
Commits a387203 and 07cbe67 enable per-batch normalization at embedding generation, allowing the model to run on very large datasets. (Please ignore all prior commits)

Fixes #13 